### PR TITLE
v0.1.6

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -24,8 +24,19 @@ pytest tests --git-url=https://github.com/difegue/LANraragi.git --git-branch=dev
 ```
 
 Start integration tests on a local path.
-```
+```sh
 pytest tests --build /path/to/LANraragi/project
+```
+
+To see LRR docker container logs accompanying a test failure, use the pytest flag `--log-cli-level=ERROR`:
+```sh
+pytest tests --log-cli-level=ERROR
+tests/test_simple.py::test_fail 
+# ------------------------------------------------------- live log call --------------------------------------------------------
+# ERROR    tests.conftest:conftest.py:84 Test failed: tests/test_simple.py::test_fail
+# ERROR    aio_lanraragi_tests.lrr_docker:conftest.py:96 LRR: s6-rc: info: service s6rc-oneshot-runner: starting
+# ERROR    aio_lanraragi_tests.lrr_docker:conftest.py:96 LRR: s6-rc: info: service s6rc-oneshot-runner successfully started
+# ERROR    aio_lanraragi_tests.lrr_docker:conftest.py:96 LRR: s6-rc: info: service fix-attrs: starting
 ```
 
 See [pytest](https://docs.pytest.org/en/stable/#) docs for more test-related options.

--- a/integration_tests/src/aio_lanraragi_tests/lrr_docker.py
+++ b/integration_tests/src/aio_lanraragi_tests/lrr_docker.py
@@ -98,6 +98,26 @@ class LRREnvironment:
     def allow_uploads(self):
         return self.lrr_container.exec_run(["sh", "-c", 'chown -R koyomi: content'])
 
+    def get_lrr_logs(self, tail: int = 100) -> bytes:
+        """
+        Get the LANraragi container logs as bytes.
+        """
+        if self.lrr_container:
+            return self.lrr_container.logs(tail=tail)
+        else:
+            self.logger.warning("LANraragi container not available for log extraction")
+            return b"No LANraragi container available"
+
+    def get_redis_logs(self, tail: int = 100) -> bytes:
+        """
+        Get the Redis container logs.
+        """
+        if self.redis_container:
+            return self.redis_container.logs(tail=tail)
+        else:
+            self.logger.warning("Redis container not available for log extraction")
+            return b"No Redis container available"
+
     def setup(self):
         # prepare images
         if self.build_path:

--- a/integration_tests/src/aio_lanraragi_tests/lrr_docker.py
+++ b/integration_tests/src/aio_lanraragi_tests/lrr_docker.py
@@ -146,24 +146,30 @@ class LRREnvironment:
             self.logger.warning("Redis container not available for log extraction")
             return b"No Redis container available"
 
-    def display_lrr_logs(self, tail: int=100):
+    def display_lrr_logs(self, tail: int=100, log_level: int=logging.ERROR):
+        """
+        Display LRR logs to (error) output, used for debugging.
+
+        Args:
+            tail: show up to how many lines from the last output
+            log_level: integer value level of log (see logging module)
+        """
         lrr_logs = self.get_lrr_logs(tail=tail)
         if lrr_logs:
             log_text = lrr_logs.decode('utf-8', errors='replace')
             for line in log_text.split('\n'):
                 if line.strip():
-                    self.logger.error(f"LRR: {line}")
+                    self.logger.log(log_level, f"LRR: {line}")
+                    # self.logger.error(f"LRR: {line}")
 
-    def setup(self, test_connection_max_retries: int=3):
+    def setup(self, test_connection_max_retries: int=4):
         """
         Main entrypoint to setting up a LRR docker environment. Pulls/builds required images,
         creates/recreates required volumes, containers, networks, and connects them together,
         as well as any other configuration.
 
-        `test_connection_max_retries`: int
-
-            Number of attempts to connect to the LRR server. Usually resolves after 2, unless
-            there are many files.
+        Args:
+            test_connection_max_retries: Number of attempts to connect to the LRR server. Usually resolves after 2, unless there are many files.
         """
 
         # prepare images

--- a/integration_tests/tests/conftest.py
+++ b/integration_tests/tests/conftest.py
@@ -83,16 +83,52 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[Any]):
     outcome = yield
     report: TestReport = outcome.get_result()
     if report.when == "call" and report.failed:
-        logger.error(f"Test failed: {item.nodeid}")
+        logger.info(f"Test failed: {item.nodeid}")
+
+        # # TODO: don't delete this tutorial; will probably use this in the future. (9/6/25)
+        # # Log exception details from the report
+        # if report.longrepr:
+        #     logger.info(f"Exception details: {report.longrepr}")
+        
+        # # Access the raw exception from the call info if available
+        # if hasattr(call, 'excinfo') and call.excinfo:
+        #     excinfo = call.excinfo
+        #     exc_class = excinfo.type
+        #     exc_instance = excinfo.value
+            
+        #     logger.info(f"Exception class: {exc_class}")
+        #     logger.info(f"Exception type name: {exc_class.__name__}")
+        #     logger.info(f"Exception module: {exc_class.__module__}")
+        #     logger.info(f"Exception value: {exc_instance}")
+        #     logger.info(f"Exception message: {str(exc_instance)}")
+            
+        #     # Handle custom exceptions with error codes
+        #     if hasattr(exc_instance, 'error_code'):
+        #         logger.info(f"Custom error code: {exc_instance.error_code}")
+            
+        #     if hasattr(exc_instance, 'details'):
+        #         logger.info(f"Custom details: {exc_instance.details}")
+            
+        #     # Pattern matching for specific exception types
+        #     if exc_class == KeyError:
+        #         logger.info("Handling KeyError: Missing key in dictionary/mapping")
+        #     elif exc_class == ValueError:
+        #         logger.info("Handling ValueError: Invalid value provided")
+        #     elif exc_class.__name__ == 'AssertionError':
+        #         logger.info("Handling AssertionError: Test assertion failed")
+        #     elif exc_class.__module__ != 'builtins':
+        #         logger.info(f"Custom exception detected from module: {exc_class.__module__}")
+            
+        #     # Check if it's a subclass of specific exceptions
+        #     if issubclass(exc_class, ConnectionError):
+        #         logger.info("This is a connection-related error")
+        #     elif issubclass(exc_class, OSError):
+        #         logger.info("This is an OS-related error")
+        
         try:
             if hasattr(item.session, 'lrr_environment'):
                 environment: LRREnvironment = item.session.lrr_environment
-                lrr_logs = environment.get_lrr_logs()
-                if lrr_logs:
-                    log_text = lrr_logs.decode('utf-8', errors='replace')
-                    for line in log_text.split('\n'):
-                        if line.strip():
-                            environment.logger.error(f"LRR: {line}")
+                environment.display_lrr_logs()
             else:
                 logger.warning("LRR environment not available in session for failure debugging")
         except Exception as e:

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -91,7 +91,10 @@ def session_setup_teardown(request: pytest.FixtureRequest):
     use_docker_api: bool = request.config.getoption("--docker-api")
     docker_client = docker.from_env()
     docker_api = docker.APIClient(base_url="unix://var/run/docker.sock") if use_docker_api else None
-    environment = LRREnvironment(build_path, image, git_url, git_branch, docker_client, docker_api=docker_api)
+    environment = LRREnvironment(
+        build_path, image, git_url, git_branch, docker_client, docker_api=docker_api,
+        init_with_allow_uploads=True, init_with_api_key=True, init_with_nofunmode=True
+    )
     environment.setup()
     request.session.lrr_environment = environment # Store environment in pytest session for access in hooks
     yield

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -1087,13 +1087,13 @@ async def test_concurrent_clients():
     session = aiohttp.ClientSession()
     try:
         client1 = LRRClient(
-            lrr_host="http://localhost:3001", 
-            lrr_api_key="lanraragi", 
+            lrr_host="http://localhost:3001",
+            lrr_api_key="lanraragi",
             session=session
         )
         client2 = LRRClient(
-            lrr_host="http://localhost:3001", 
-            lrr_api_key="lanraragi", 
+            lrr_host="http://localhost:3001",
+            lrr_api_key="lanraragi",
             session=session
         )
         results = await asyncio.gather(

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -34,6 +34,7 @@ from lanraragi.models.archive import (
     ExtractArchiveRequest,
     GetArchiveMetadataRequest,
     GetArchiveThumbnailRequest,
+    UpdateArchiveThumbnailRequest,
     UpdateReadingProgressionRequest,
     UploadArchiveRequest,
     UploadArchiveResponse,
@@ -342,6 +343,13 @@ async def test_archive_read(lanraragi: LRRClient, semaphore: asyncio.Semaphore):
     assert response.content_type is not None, "Expected content_type to be set in regular response"
     del response, error
     # <<<<< TEST THUMBNAIL STAGE <<<<<
+
+    # >>>>> UPDATE ARCHIVE THUMBNAIL STAGE >>>>>
+    response, error = await retry_on_lock(lambda: lanraragi.archive_api.update_thumbnail(UpdateArchiveThumbnailRequest(arcid=first_archive_id, page=2)))
+    assert not error, f"Failed to update thumbnail to page 2 (status {error.status}): {error.error}"
+    assert response.new_thumbnail, "Expected new_thumbnail field to be populated"
+    del response, error
+    # <<<<< UPDATE ARCHIVE THUMBNAIL STAGE <<<<<
 
     # <<<<< GET ALL ARCHIVES STAGE <<<<<
 

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -452,7 +452,6 @@ async def test_category(lanraragi: LRRClient):
     # <<<<< UNLINK BOOKMARK <<<<<
 
 @pytest.mark.asyncio
-@pytest.mark.failing
 async def test_archive_category_interaction(lanraragi: LRRClient, semaphore: asyncio.Semaphore):
     """
     Creates 100 archives to upload to the LRR server, with an emphasis on testing category/archive addition/removal

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -31,6 +31,8 @@ from aio_lanraragi_tests.archive_generation.metadata import create_tag_generator
 from lanraragi.clients.utils import _build_err_response
 from lanraragi.models.archive import (
     ClearNewArchiveFlagRequest,
+    DeleteArchiveRequest,
+    DeleteArchiveResponse,
     ExtractArchiveRequest,
     GetArchiveMetadataRequest,
     GetArchiveThumbnailRequest,
@@ -161,6 +163,19 @@ async def upload_archive(client: LRRClient, save_path: Path, filename: str, sema
             request = UploadArchiveRequest(file=file, filename=filename, title=title, tags=tags, file_checksum=checksum)
         return await client.archive_api.upload_archive(request)
 
+async def delete_archive(client: LRRClient, arcid: str, semaphore: asyncio.Semaphore) -> Tuple[DeleteArchiveResponse, LanraragiErrorResponse]:
+    retry_count = 0
+    async with semaphore:
+        while True:
+            response, error = await client.archive_api.delete_archive(DeleteArchiveRequest(arcid=arcid))
+            if error and error.status == 423: # locked resource
+                retry_count += 1
+                if retry_count > 10:
+                    return response, error
+                await asyncio.sleep(2 ** retry_count)
+                continue
+            return response, error
+
 async def add_archive_to_category(client: LRRClient, category_id: str, arcid: str, semaphore: asyncio.Semaphore) -> Tuple[AddArchiveToCategoryResponse, LanraragiErrorResponse]:
     retry_count = 0
     async with semaphore:
@@ -226,8 +241,11 @@ def save_archives(num_archives: int, work_dir: Path, np_generator: np.random.Gen
 @pytest.mark.asyncio
 async def test_archive_upload(lanraragi: LRRClient, semaphore: asyncio.Semaphore):
     """
-    Creates 100 archives to upload to the LRR server, 
-    then verifies that this number of archives is correct.
+    Creates 100 archives to upload to the LRR server,
+    and verifies that this number of archives is correct.
+
+    Then deletes 50 archives (5 sequentially, followed by
+    45 concurrently). Verifies archive count is correct.
     """
     generator = np.random.default_rng(42)
     num_archives = 100
@@ -272,6 +290,10 @@ async def test_archive_upload(lanraragi: LRRClient, semaphore: asyncio.Semaphore
     logger.debug("Validating upload counts.")
     response, error = await lanraragi.archive_api.get_all_archives()
     assert not error, f"Failed to get archive data (status {error.status}): {error.error}"
+
+    # get this data for archive deletion.
+    arcs_delete_sync = response.data[:5]
+    arcs_delete_async = response.data[5:50]
     assert len(response.data) == num_archives, "Number of archives on server does not equal number uploaded!"
     # <<<<< VALIDATE UPLOAD COUNT STAGE <<<<<
 
@@ -281,6 +303,27 @@ async def test_archive_upload(lanraragi: LRRClient, semaphore: asyncio.Semaphore
     assert len(response.archives) == num_archives, "Number of archives in database backup does not equal number uploaded!"
     del response, error
     # <<<<< GET DATABASE BACKUP STAGE <<<<<
+
+    # >>>>> DELETE ARCHIVE SYNC STAGE >>>>>
+    for archive in arcs_delete_sync:
+        response, error = await lanraragi.archive_api.delete_archive(DeleteArchiveRequest(arcid=archive.arcid))
+        assert not error, f"Failed to delete archive {archive.arcid} with status {error.status} and error: {error.error}"
+    response, error = await lanraragi.archive_api.get_all_archives()
+    assert not error, f"Failed to get archive data (status {error.status}): {error.error}"
+    assert len(response.data) == 100-5, "Incorrect number of archives in server!"
+    # <<<<< DELETE ARCHIVE SYNC STAGE <<<<<
+
+    # >>>>> DELETE ARCHIVE ASYNC STAGE >>>>>
+    tasks = []
+    for archive in arcs_delete_async:
+        tasks.append(asyncio.create_task(delete_archive(lanraragi, archive.arcid, semaphore)))
+    gathered: List[Tuple[DeleteArchiveResponse, LanraragiErrorResponse]] = await asyncio.gather(*tasks)
+    for response, error in gathered:
+        assert not error, f"Delete archive failed (status {error.status}): {error.error}"
+    response, error = await lanraragi.archive_api.get_all_archives()
+    assert not error, f"Failed to get archive data (status {error.status}): {error.error}"
+    assert len(response.data) == 100-50, "Incorrect number of archives in server!"
+    # <<<<< DELETE ARCHIVE ASYNC STAGE <<<<<
 
 @pytest.mark.asyncio
 async def test_archive_read(lanraragi: LRRClient, semaphore: asyncio.Semaphore):

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -90,6 +90,7 @@ def session_setup_teardown(request: pytest.FixtureRequest):
     docker_api = docker.APIClient(base_url="unix://var/run/docker.sock") if use_docker_api else None
     environment = LRREnvironment(build_path, image, git_url, git_branch, docker_client, docker_api=docker_api)
     environment.setup()
+    request.session.lrr_environment = environment # Store environment in pytest session for access in hooks
     yield
     environment.teardown()
 

--- a/integration_tests/tests/test_simple.py
+++ b/integration_tests/tests/test_simple.py
@@ -329,6 +329,19 @@ async def test_archive_read(lanraragi: LRRClient, semaphore: asyncio.Semaphore):
     assert not error, f"Failed to get all archives (status {error.status}): {error.error}"
     assert len(response.data) == num_archives, "Number of archives on server does not equal number uploaded!"
     first_archive_id = response.data[0].arcid
+
+    # >>>>> TEST THUMBNAIL STAGE >>>>>
+    response, error = await lanraragi.archive_api.get_archive_thumbnail(GetArchiveThumbnailRequest(arcid=first_archive_id, nofallback=True))
+    assert not error, f"Failed to get thumbnail with no_fallback=True (status {error.status}): {error.error}"
+    del response, error
+
+    response, error = await lanraragi.archive_api.get_archive_thumbnail(GetArchiveThumbnailRequest(arcid=first_archive_id))
+    assert not error, f"Failed to get thumbnail with default settings (status {error.status}): {error.error}"
+    assert response.content is not None, "Thumbnail content should not be None with default settings"
+    assert response.content_type is not None, "Expected content_type to be set in regular response"
+    del response, error
+    # <<<<< TEST THUMBNAIL STAGE <<<<<
+
     # <<<<< GET ALL ARCHIVES STAGE <<<<<
 
     # >>>>> SIMULATE READ ARCHIVE STAGE >>>>>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aio-lanraragi"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     {name="psilabs-dev"}
 ]

--- a/src/lanraragi/clients/api_clients/archive.py
+++ b/src/lanraragi/clients/api_clients/archive.py
@@ -106,7 +106,7 @@ class _ArchiveApiClient(_ApiClient):
         if request.page:
             params["page"] = request.page
         if request.nofallback:
-            params["nofallback"] = str(request.nofallback).lower()
+            params["no_fallback"] = str(request.nofallback).lower()
         status, data = await self.api_context.download_thumbnail(url, self.api_context.headers, params=params)
         if status in [200, 202]:
             return (_process_get_archive_thumbnail_response(data, status), None)

--- a/src/lanraragi/clients/utils.py
+++ b/src/lanraragi/clients/utils.py
@@ -1,11 +1,18 @@
 import json
+
 from lanraragi.models.base import LanraragiErrorResponse
 
 def _build_err_response(content: str, status: int) -> LanraragiErrorResponse:
     try:
         response_j = json.loads(content)
-        response = LanraragiErrorResponse(error=response_j.get("error"), status=status)
-        return response
+
+        # ideally, LRR will return an error message in the usual format.
+        # however, if e.g. openapi returns "errors" instead, we'll just dump the entire message.
+        if "error" in response_j:
+            response = LanraragiErrorResponse(error=str(response_j.get("error")), status=status)
+            return response
+        else:
+            return LanraragiErrorResponse(error=str(response_j), status=status)
     except json.decoder.JSONDecodeError:
         err_message = f"Error while decoding JSON from response: {content}"
         response = LanraragiErrorResponse(error=err_message, status=status)


### PR DESCRIPTION
- adds test for concurrent archive/category API calls
- fixes "nofallback" typo
- add tests for thumbnail extraction jobs
- adds docker log dumps on test failures
- add delete archive tests